### PR TITLE
Fixes RT#91029 Class::MOP::load_class deprecation warning

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,3 +12,4 @@ Mouse = 0
 Moose = 0
 MooseX::Getopt::Dashes = 0
 MouseX::Getopt::Dashes = 0
+Class::Load = 0.20

--- a/lib/Bot/Training.pm
+++ b/lib/Bot/Training.pm
@@ -69,8 +69,8 @@ sub _new_class {
     }
 
     if (Any::Moose::moose_is_preferred()) {
-        require Class::MOP;
-        eval { Class::MOP::load_class($pkg) };
+        require Class::Load;
+        eval { Class::Load::load_class($pkg) };
     } else {
         eval qq[require $pkg];
     }
@@ -108,7 +108,7 @@ sub run {
             return 1;
         }
     }
-    
+
     if ($self->_go_file) {
         my $trn = $self->file( $self->_go_file );;
         open my $fh, "<", $trn->file;


### PR DESCRIPTION
This fixes RT#91029: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=91029
